### PR TITLE
Add a node bin script for calling this logic from shell

### DIFF
--- a/bin/portfinder
+++ b/bin/portfinder
@@ -1,10 +1,31 @@
 #!/usr/bin/env node
-var portfinder = require('portfinder')
-  , argv = require('optimist').argv;
+
+var getNamedArguments = function() {
+  var lastArg = false
+    , namedArgs = {};
   
+  process.argv.slice(2).forEach(function(argument) {
+    if (lastArg !== false && argument.indexOf('--') === -1) {
+      var arg = parseInt(argument, 10);
+      namedArgs[lastArg] = (isNaN(arg) === false) ? arg : argument;
+    }
+  
+    if (argument.indexOf('--') === 0) {
+      lastArg = argument.slice(2);
+    } else {
+      lastArg = false;
+    }
+  });
+  
+  return namedArgs;
+};
+
+var portfinder = require('../lib/portfinder')
+  , namedArgs = getNamedArguments();
+    
 var options = {
-  port: argv.start || portfinder.basePort,
-  host: argv.host  || null
+  port: namedArgs.start || portfinder.basePort,
+  host: namedArgs.host  || null
 };
 
 portfinder.getPort(options, function (err, port) {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "utilities"
   ],
   "dependencies": {
-    "mkdirp": "0.0.x",
-    "optimist": "0.6.1"
+    "mkdirp": "0.0.x"
   },
   "devDependencies": {
     "async": "0.1.x",


### PR DESCRIPTION
I'd like to use this code in a CI environment to grab an unused port on the machine so that I can spin up the same codebase on multiple ports (CI concurrency FTW!). Rather than just write this logic into my codebase I figured this could be useful for others.
