### PR TITLE
Pevent recusive call for getPort and getSocket

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -55,11 +55,15 @@ exports.getPort = function (options, callback) {
       return callback(err);
     }
 
-    exports.getPort({
-      port: exports.nextPort(options.port),
-      host: options.host,
-      server: options.server
-    }, callback);
+    //Failed to open server on this port, try next port.
+    //NOTE: Use setImmediate to prevent infinite recusive function in case of no ports found.
+    setImmediate(function(){
+        exports.getPort({
+          port: exports.nextPort(options.port),
+          host: options.host,
+          server: options.server
+        }, callback);
+    });
   }
 
   options.server.once('error', onError);
@@ -105,8 +109,13 @@ exports.getSocket = function (options, callback) {
         // This file exists, so it isn't possible to listen on it. Lets try
         // next socket.
         //
-        options.path = exports.nextSocket(options.path);
-        exports.getSocket(options, callback);
+        
+        //Failed to open socket, try next socket.
+        //NOTE: Use setImmediate to prevent infinite recusive function in case of no sockets found.
+        setImmediate(function(){
+           options.path = exports.nextSocket(options.path);
+           exports.getSocket(options, callback);
+        }
       }
     });
   }


### PR DESCRIPTION
This example crashes the application:

for(var port = 8000; port < 9000; port++) net.createServer().listen(port);
portFinder.getPort(function(err, port){console.log("Found port " + port);});

because when portFinder.getPort fails to open a port, it call getPort recursively.
