### PR TITLE
Set license to "MIT" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
   "main": "./lib/portfinder",
   "scripts": { "test": "vows test/*-test.js --spec" },
   "engines": { "node": ">= 0.8.0" },
-  "license": "MIT/X11"
+  "license": "MIT"
 }


### PR DESCRIPTION
This tiny pull request replaces `MIT/X11` with just `MIT` in package.json, so you won't get a validation warnings about a non-[SPDX](http://spdx.org/licenses) license identifier.