### PR TITLE
Fix wrong duplicate removal

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -80,8 +80,11 @@ exports.getPort = function (options, callback) {
   var hosts = [options.host, '0.0.0.0', '127.0.0.1'];
 
   // remove duplicate host arg if already in hosts array
-  for (var i = 0; i < hosts.length; i++) {
-    if (options.host === hosts[i]) { hosts.shift(); }
+  for (var i = 1; i < hosts.length; i++) {
+    if (options.host === hosts[i]) {
+      hosts.shift();
+      break;
+    }
   }
 
   // create array of eventual found ports for each host


### PR DESCRIPTION
This fixes the removal of `options.host` that is always happening because the loop starts from `0` instead of `1`. It also stops the check as soon as a duplicate is found.