### PR TITLE
Treat an EAFNOSUPPORT error as a common open port

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -36,6 +36,14 @@ internals.testPort = function(options, callback) {
   function onError (err) {
     options.server.removeListener('listening', onListen);
 
+    //
+    // If address is not supported on this system (e.g. `::1` on a system with
+    // the IPv6 stack disabled), treat as a "common" open port
+    //
+    if (err.code === 'EAFNOSUPPORT') {
+      return callback(null, options.port);
+    }
+
     if (err.code !== 'EADDRINUSE' && err.code !== 'EACCES') {
       return callback(err);
     }


### PR DESCRIPTION
On a system with the IPv6 stack turned off, testing against `::1` raises an `EAFNOSUPPORT` error and portfinder fails to return an open port.

Since the spirit of this is to find an open port "common" to all the `hosts` tested, I think an easy fix is to just treat `EAFNOSUPPORT` like "yes, this port is OK, since this host isn't even available on this system".

Thanks for the project!