### PR TITLE
Remove ipv6 from default hosts on failure

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -70,49 +70,76 @@ exports.basePath = '/tmp/portfinder'
 // #### @callback {function} Continuation to respond to when complete.
 // Responds with a unbound port on the current machine.
 //
+
+var defaultHosts = ['::1', '127.0.0.1', '0.0.0.0'];
 exports.getPort = function (options, callback) {
   if (!callback) {
     callback = options;
     options = {};
   }
 
-  var hosts = ['::1', '127.0.0.1', '0.0.0.0'];
   if (options.host) {
-    hosts.push(options.host);
-  }
 
-  function findCommonOpenPort(portToTest) {
-    var ports = [];
-    var error;
-    async.everyLimit(hosts, 1, function(host, next) {
-      internals.testPort({"host": host, "port": portToTest}, function(err, port) {
-        if (err) {
-          error = err;
-          return next(false); 
-        } else {
-          ports.push(port);
-	  next(port);
-        }
-      });
-    }, function(result) {
-      if (!result) {
-        return callback(error);
-      } 
-
-      ports.sort(function(a, b) {
-        return a - b;
-      });
-
-      if (ports[0] === ports[ports.length-1]) {
-        callback(null, ports[0]);
-      } else {
-        findCommonOpenPort(ports.pop());
+    var hasUserGivenHost;
+    for (var i = 0; i < defaultHosts.length; i++) {
+      if (defaultHosts[i] === options.host) {
+        hasUserGivenHost = true;
+        break;
       }
-      
-    });
+    }
+
+    if (!hasUserGivenHost) {
+      defaultHosts.push(options.host);
+    }
+
   }
 
-  findCommonOpenPort(options.port);
+  var openPorts = [];
+  return async.eachSeries(defaultHosts, function(host, next) {
+    return internals.testPort({ host: host, port: options.port }, function(err, port) {
+      if (err) {
+        return next(err);
+      } else {
+        openPorts.push(port);
+        return next();
+      }
+    });
+  }, function(err) {
+    if (err) {
+      if (err.address && net.isIPv6(err.address)) {
+        if (options.host && net.isIPv6(options.host)) {
+          // let user know if they provided an ipv6 host, bail
+          var msg = 'Provided host ' + options.host +
+                    ' is ipv6 and your system does not support it.'+
+                    ' Please provide a host that is ipv4';
+          return callback(Error(msg));
+        } else {
+          // filter our defaultHosts to only be ipv4, start over
+          defaultHosts = defaultHosts.filter(function(_host) {
+            return net.isIPv4(_host);
+          });
+          return exports.getPort(options, callback);
+        }
+      } else {
+        // error is not ipv6 related, file ticket, handle as special case
+        return callback(error);
+      }
+    }
+
+    // sort so we can compare first host to last host
+    openPorts.sort(function(a, b) {
+      return a - b;
+    });
+
+    if (openPorts[0] === openPorts[openPorts.length-1]) {
+      // if first === last, we found an open port
+      return callback(null, openPorts[0]);
+    } else {
+      // otherwise, try again, using sorted port, aka, highest open for >= 1 host
+      return exports.getPort({ port: openPorts.pop(), host: options.host }, callback);
+    }
+
+  });
 };
 
 //

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -28,6 +28,15 @@ vows.describe('portfinder').addBatch({
           assert.isTrue(!err);
           assert.equal(port, 32773);
         }
+      },
+      "the getPort() method with user passed duplicate host": {
+        topic: function () {
+          portfinder.getPort({ host: '127.0.0.1' }, this.callback);
+        },
+        "should respond with the first free port (32774)": function (err, port) {
+          assert.isTrue(!err);
+          assert.equal(port, 32774);
+        }
       }
     }
   }


### PR DESCRIPTION
Remove ipv6 from default hosts that we test each port against 
to allow portfinder to work with machines that dont have ipv6

fixes #26 #28 