### PR TITLE
Revert changes pushed in 1.0.4

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -8,7 +8,6 @@
 "use strict";
 
 var fs = require('fs'),
-    os = require('os'),
     net = require('net'),
     path = require('path'),
     async = require('async'),
@@ -73,6 +72,8 @@ exports.basePath = '/tmp/portfinder'
 // #### @callback {function} Continuation to respond to when complete.
 // Responds with a unbound port on the current machine.
 //
+
+var defaultHosts = ['::1', '127.0.0.1', '0.0.0.0'];
 exports.getPort = function (options, callback) {
   if (!callback) {
     callback = options;
@@ -82,21 +83,21 @@ exports.getPort = function (options, callback) {
   if (options.host) {
 
     var hasUserGivenHost;
-    for (var i = 0; i < exports._defaultHosts.length; i++) {
-      if (exports._defaultHosts[i] === options.host) {
+    for (var i = 0; i < defaultHosts.length; i++) {
+      if (defaultHosts[i] === options.host) {
         hasUserGivenHost = true;
         break;
       }
     }
 
     if (!hasUserGivenHost) {
-      exports._defaultHosts.push(options.host);
+      defaultHosts.push(options.host);
     }
 
   }
 
   var openPorts = [];
-  return async.eachSeries(exports._defaultHosts, function(host, next) {
+  return async.eachSeries(defaultHosts, function(host, next) {
     return internals.testPort({ host: host, port: options.port }, function(err, port) {
       if (err) {
         return next(err);
@@ -107,15 +108,6 @@ exports.getPort = function (options, callback) {
     });
   }, function(err) {
     if (err) {
-
-      // Handle MacOS 10.11.5+ interface changes and running portfinder from
-      // within the same netmask, including from within a locally running VM.
-      if (err.code === 'EADDRNOTAVAIL') {
-        var idx = exports._defaultHosts.indexOf(err.address);
-        exports._defaultHosts.splice(idx, 1);
-      }
-
-      // NOTE: net.isIPv6(err.address) check is likely === EADDRNOTAVAIL check above (+risk)
       if (err.address && net.isIPv6(err.address)) {
         if (options.host && net.isIPv6(options.host)) {
           // let user know if they provided an ipv6 host, bail
@@ -125,7 +117,7 @@ exports.getPort = function (options, callback) {
           return callback(Error(msg));
         } else {
           // filter our defaultHosts to only be ipv4, start over
-          exports._defaultHosts = exports._defaultHosts.filter(function(_host) {
+          defaultHosts = defaultHosts.filter(function(_host) {
             return net.isIPv4(_host);
           });
           return exports.getPort(options, callback);
@@ -300,94 +292,3 @@ exports.nextSocket = function (socketPath) {
   index += 1;
   return path.join(dir, base + index + '.sock');
 };
-
-/**
- * @desc List of internal hostnames provided by your machine. A user
- *       provided hostname may also be provided when calling portfinder.getPort,
- *       which would then be added to the default hosts we lookup and return here.
- *
- * @return {array}
- *
- * Long Form Explantion:
- *
- *    - Input: (os.networkInterfaces() w/ MacOS 10.11.5+ and running a VM)
- *
- *        { lo0:
- *         [ { address: '::1',
- *             netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
- *             family: 'IPv6',
- *             mac: '00:00:00:00:00:00',
- *             scopeid: 0,
- *             internal: true },
- *           { address: '127.0.0.1',
- *             netmask: '255.0.0.0',
- *             family: 'IPv4',
- *             mac: '00:00:00:00:00:00',
- *             internal: true },
- *           { address: 'fe80::1',
- *             netmask: 'ffff:ffff:ffff:ffff::',
- *             family: 'IPv6',
- *             mac: '00:00:00:00:00:00',
- *             scopeid: 1,
- *             internal: true } ],
- *        en0:
- *         [ { address: 'fe80::a299:9bff:fe17:766d',
- *             netmask: 'ffff:ffff:ffff:ffff::',
- *             family: 'IPv6',
- *             mac: 'a0:99:9b:17:76:6d',
- *             scopeid: 4,
- *             internal: false },
- *           { address: '10.0.1.22',
- *             netmask: '255.255.255.0',
- *             family: 'IPv4',
- *             mac: 'a0:99:9b:17:76:6d',
- *             internal: false } ],
- *        awdl0:
- *         [ { address: 'fe80::48a8:37ff:fe34:aaef',
- *             netmask: 'ffff:ffff:ffff:ffff::',
- *             family: 'IPv6',
- *             mac: '4a:a8:37:34:aa:ef',
- *             scopeid: 8,
- *             internal: false } ],
- *        vnic0:
- *         [ { address: '10.211.55.2',
- *             netmask: '255.255.255.0',
- *             family: 'IPv4',
- *             mac: '00:1c:42:00:00:08',
- *             internal: false } ],
- *        vnic1:
- *         [ { address: '10.37.129.2',
- *             netmask: '255.255.255.0',
- *             family: 'IPv4',
- *             mac: '00:1c:42:00:00:09',
- *             internal: false } ] }
- *
- *    - Output:
- *
- *         [
- *          '0.0.0.0',
- *          '::1',
- *          '127.0.0.1',
- *          '10.0.1.22',
- *          '10.211.55.2',
- *          '10.37.129.2'
- *         ]
- *
- *     Note we export this so we can use it in our tests, otherwise this API is private
- */
-exports._defaultHosts = (function() {
-  var interfaces = os.networkInterfaces(),
-      interfaceNames = Object.keys(interfaces),
-      hiddenButImportantHost = '0.0.0.0', // !important - dont remove, hence the naming :)
-      results = [hiddenButImportantHost];
-  for (var i = 0; i < interfaceNames.length; i++) {
-    var _interface = interfaces[interfaceNames[i]];
-    for (var j = 0; j < _interface.length; j++) {
-      var curr = _interface[j];
-      if (curr.internal || curr.netmask === '255.255.255.0') {
-        results.push(curr.address);
-      }
-    }
-  }
-  return results;
-}());

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,8 +1,7 @@
 "use strict";
 
 var async = require('async'),
-    http = require('http'),
-    portfinder = require('..');
+    http = require('http');
 
 
 function createServer(base, host, next) {
@@ -27,7 +26,7 @@ module.exports = function(servers, callback) {
   async.whilst(
     function () { return base < 32773; },
     function (next) {
-      var hosts = [].concat(portfinder._defaultHosts);
+      var hosts = ['127.0.0.1', '0.0.0.0', '::1'];
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }
       servers.push(createServer(base, hosts.shift(), next)); // call next for host
       base++;


### PR DESCRIPTION
Issue #34 that arose out of portfinder 1.0.4 is a breaking change. Revert. We'll approach this in a more conservative fashion in an upcoming (likely) major release.