### PR TITLE
Catch eaddrnotavail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script:
 notifications:
   email:
     - charlie.robbins@gmail.com
+    - erik.trom.github@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - travis_retry npm install
 
 script:
-  - npm test
+  - DEBUG=* npm test
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ install:
 test_script:
   # Output useful info for debugging.
   - npm version
+  - cmd: set DEBUG=*
   - cmd: npm test
 
 # Don't actually build.

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -8,6 +8,7 @@
 "use strict";
 
 var fs = require('fs'),
+    os = require('os'),
     net = require('net'),
     path = require('path'),
     async = require('async'),
@@ -72,8 +73,6 @@ exports.basePath = '/tmp/portfinder'
 // #### @callback {function} Continuation to respond to when complete.
 // Responds with a unbound port on the current machine.
 //
-
-var defaultHosts = ['::1', '127.0.0.1', '0.0.0.0'];
 exports.getPort = function (options, callback) {
   if (!callback) {
     callback = options;
@@ -83,21 +82,21 @@ exports.getPort = function (options, callback) {
   if (options.host) {
 
     var hasUserGivenHost;
-    for (var i = 0; i < defaultHosts.length; i++) {
-      if (defaultHosts[i] === options.host) {
+    for (var i = 0; i < exports._defaultHosts.length; i++) {
+      if (exports._defaultHosts[i] === options.host) {
         hasUserGivenHost = true;
         break;
       }
     }
 
     if (!hasUserGivenHost) {
-      defaultHosts.push(options.host);
+      exports._defaultHosts.push(options.host);
     }
 
   }
 
   var openPorts = [];
-  return async.eachSeries(defaultHosts, function(host, next) {
+  return async.eachSeries(exports._defaultHosts, function(host, next) {
     return internals.testPort({ host: host, port: options.port }, function(err, port) {
       if (err) {
         return next(err);
@@ -108,6 +107,15 @@ exports.getPort = function (options, callback) {
     });
   }, function(err) {
     if (err) {
+
+      // Handle MacOS 10.11.5+ interface changes and running portfinder from
+      // within the same netmask, including from within a locally running VM.
+      if (err.code === 'EADDRNOTAVAIL') {
+        var idx = exports._defaultHosts.indexOf(err.address);
+        exports._defaultHosts.splice(idx, 1);
+      }
+
+      // NOTE: net.isIPv6(err.address) check is likely === EADDRNOTAVAIL check above (+risk)
       if (err.address && net.isIPv6(err.address)) {
         if (options.host && net.isIPv6(options.host)) {
           // let user know if they provided an ipv6 host, bail
@@ -117,7 +125,7 @@ exports.getPort = function (options, callback) {
           return callback(Error(msg));
         } else {
           // filter our defaultHosts to only be ipv4, start over
-          defaultHosts = defaultHosts.filter(function(_host) {
+          exports._defaultHosts = exports._defaultHosts.filter(function(_host) {
             return net.isIPv4(_host);
           });
           return exports.getPort(options, callback);
@@ -292,3 +300,94 @@ exports.nextSocket = function (socketPath) {
   index += 1;
   return path.join(dir, base + index + '.sock');
 };
+
+/**
+ * @desc List of internal hostnames provided by your machine. A user
+ *       provided hostname may also be provided when calling portfinder.getPort,
+ *       which would then be added to the default hosts we lookup and return here.
+ *
+ * @return {array}
+ *
+ * Long Form Explantion:
+ *
+ *    - Input: (os.networkInterfaces() w/ MacOS 10.11.5+ and running a VM)
+ *
+ *        { lo0:
+ *         [ { address: '::1',
+ *             netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+ *             family: 'IPv6',
+ *             mac: '00:00:00:00:00:00',
+ *             scopeid: 0,
+ *             internal: true },
+ *           { address: '127.0.0.1',
+ *             netmask: '255.0.0.0',
+ *             family: 'IPv4',
+ *             mac: '00:00:00:00:00:00',
+ *             internal: true },
+ *           { address: 'fe80::1',
+ *             netmask: 'ffff:ffff:ffff:ffff::',
+ *             family: 'IPv6',
+ *             mac: '00:00:00:00:00:00',
+ *             scopeid: 1,
+ *             internal: true } ],
+ *        en0:
+ *         [ { address: 'fe80::a299:9bff:fe17:766d',
+ *             netmask: 'ffff:ffff:ffff:ffff::',
+ *             family: 'IPv6',
+ *             mac: 'a0:99:9b:17:76:6d',
+ *             scopeid: 4,
+ *             internal: false },
+ *           { address: '10.0.1.22',
+ *             netmask: '255.255.255.0',
+ *             family: 'IPv4',
+ *             mac: 'a0:99:9b:17:76:6d',
+ *             internal: false } ],
+ *        awdl0:
+ *         [ { address: 'fe80::48a8:37ff:fe34:aaef',
+ *             netmask: 'ffff:ffff:ffff:ffff::',
+ *             family: 'IPv6',
+ *             mac: '4a:a8:37:34:aa:ef',
+ *             scopeid: 8,
+ *             internal: false } ],
+ *        vnic0:
+ *         [ { address: '10.211.55.2',
+ *             netmask: '255.255.255.0',
+ *             family: 'IPv4',
+ *             mac: '00:1c:42:00:00:08',
+ *             internal: false } ],
+ *        vnic1:
+ *         [ { address: '10.37.129.2',
+ *             netmask: '255.255.255.0',
+ *             family: 'IPv4',
+ *             mac: '00:1c:42:00:00:09',
+ *             internal: false } ] }
+ *
+ *    - Output:
+ *
+ *         [
+ *          '0.0.0.0',
+ *          '::1',
+ *          '127.0.0.1',
+ *          '10.0.1.22',
+ *          '10.211.55.2',
+ *          '10.37.129.2'
+ *         ]
+ *
+ *     Note we export this so we can use it in our tests, otherwise this API is private
+ */
+exports._defaultHosts = (function() {
+  var interfaces = os.networkInterfaces(),
+      interfaceNames = Object.keys(interfaces),
+      hiddenButImportantHost = '0.0.0.0', // !important - dont remove, hence the naming :)
+      results = [hiddenButImportantHost];
+  for (var i = 0; i < interfaceNames.length; i++) {
+    var _interface = interfaces[interfaceNames[i]];
+    for (var j = 0; j < _interface.length; j++) {
+      var curr = _interface[j];
+      if (curr.internal || curr.netmask === '255.255.255.0') {
+        results.push(curr.address);
+      }
+    }
+  }
+  return results;
+}());

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -107,31 +107,18 @@ exports.getPort = function (options, callback) {
     });
   }, function(err) {
     if (err) {
-
-      // Handle MacOS 10.11.5+ interface changes and running portfinder from
-      // within the same netmask, including from within a locally running VM.
+      // If we get EADDRNOTAVAIL it means the host is not bindable, so remove it
+      // from exports._defaultHosts and start over
+      //
+      // NOTE: this will fail if a hostname given by the user is not bindable.
+      // Aka, We may need to one day handle `my-non-existent-host.local` if users
+      // report frustration here.
       if (err.code === 'EADDRNOTAVAIL') {
         var idx = exports._defaultHosts.indexOf(err.address);
         exports._defaultHosts.splice(idx, 1);
-      }
-
-      // NOTE: net.isIPv6(err.address) check is likely === EADDRNOTAVAIL check above (+risk)
-      if (err.address && net.isIPv6(err.address)) {
-        if (options.host && net.isIPv6(options.host)) {
-          // let user know if they provided an ipv6 host, bail
-          var msg = 'Provided host ' + options.host +
-                    ' is ipv6 and your system does not support it.'+
-                    ' Please provide a host that is ipv4';
-          return callback(Error(msg));
-        } else {
-          // filter our defaultHosts to only be ipv4, start over
-          exports._defaultHosts = exports._defaultHosts.filter(function(_host) {
-            return net.isIPv4(_host);
-          });
-          return exports.getPort(options, callback);
-        }
+        return exports.getPort(options, callback);
       } else {
-        // error is not ipv6 related, file ticket, handle as special case
+        // error is not accounted for, file ticket, handle special case
         return callback(err);
       }
     }
@@ -368,7 +355,9 @@ exports.nextSocket = function (socketPath) {
  *          '0.0.0.0',
  *          '::1',
  *          '127.0.0.1',
+ *          'fe80::1',
  *          '10.0.1.22',
+ *          'fe80::48a8:37ff:fe34:aaef',
  *          '10.211.55.2',
  *          '10.37.129.2'
  *         ]
@@ -384,9 +373,7 @@ exports._defaultHosts = (function() {
     var _interface = interfaces[interfaceNames[i]];
     for (var j = 0; j < _interface.length; j++) {
       var curr = _interface[j];
-      if (curr.internal || curr.netmask === '255.255.255.0') {
-        results.push(curr.address);
-      }
+      results.push(curr.address);
     }
   }
   return results;

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -30,13 +30,20 @@ internals.testPort = function(options, callback) {
     //
   });
 
+  console.log("entered testPort(): trying", options.host, "port", options.port);
+
   function onListen () {
+    console.log("done w/ testPort(): OK", options.host, "port", options.port);
+
     options.server.removeListener('error', onError);
     options.server.close();
     callback(null, options.port);
   }
 
   function onError (err) {
+    console.log("done w/ testPort(): failed", options.host, "w/ port",
+                options.port, "with error", err.code);
+
     options.server.removeListener('listening', onListen);
 
     if (err.code !== 'EADDRINUSE' && err.code !== 'EACCES') {
@@ -97,16 +104,23 @@ exports.getPort = function (options, callback) {
 
   var openPorts = [];
   return async.eachSeries(exports._defaultHosts, function(host, next) {
+    console.log("in eachSeries() iteration callback: host is", host);
+
     return internals.testPort({ host: host, port: options.port }, function(err, port) {
       if (err) {
+        console.log("in eachSeries() iteration callback testPort() callback", "with an err:", err.code);
         return next(err);
       } else {
+        console.log("in eachSeries() iteration callback testPort() callback",
+                    "with a success for port", port);
         openPorts.push(port);
         return next();
       }
     });
   }, function(err) {
+
     if (err) {
+      console.log("in eachSeries() result callback: err is", err);
       // If we get EADDRNOTAVAIL it means the host is not bindable, so remove it
       // from exports._defaultHosts and start over. For ubuntu, we use EINVAL for the same
       if (err.code === 'EADDRNOTAVAIL' || err.code === 'EINVAL') {
@@ -134,6 +148,8 @@ exports.getPort = function (options, callback) {
     openPorts.sort(function(a, b) {
       return a - b;
     });
+
+    console.log("in eachSeries() result callback: openPorts is", openPorts);
 
     if (openPorts[0] === openPorts[openPorts.length-1]) {
       // if first === last, we found an open port

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -108,7 +108,7 @@ exports.getPort = function (options, callback) {
   }, function(err) {
     if (err) {
       // If we get EADDRNOTAVAIL it means the host is not bindable, so remove it
-      // from exports._defaultHosts and start over
+      // from exports._defaultHosts and start over. For ubuntu, we use EINVAL for the same
       if (err.code === 'EADDRNOTAVAIL' || err.code === 'EINVAL') {
 
         if (options.host === err.address) {

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -109,11 +109,18 @@ exports.getPort = function (options, callback) {
     if (err) {
       // If we get EADDRNOTAVAIL it means the host is not bindable, so remove it
       // from exports._defaultHosts and start over
-      //
-      // NOTE: this will fail if a hostname given by the user is not bindable.
-      // Aka, We may need to one day handle `my-non-existent-host.local` if users
-      // report frustration here.
       if (err.code === 'EADDRNOTAVAIL') {
+
+        if (options.host === err.address) {
+          // if bad address matches host given by user, tell them
+          //
+          // NOTE: We may need to one day handle `my-non-existent-host.local` if users
+          // report frustration with passing in hostnames that DONT map to bindable
+          // hosts, without showing them a good error.
+          var msg = 'Provided host ' + options.host + ' could NOT be bound. Please provide a different host address or hostname';
+          return callback(Error(msg));
+        }
+
         var idx = exports._defaultHosts.indexOf(err.address);
         exports._defaultHosts.splice(idx, 1);
         return exports.getPort(options, callback);

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -109,7 +109,7 @@ exports.getPort = function (options, callback) {
     if (err) {
       // If we get EADDRNOTAVAIL it means the host is not bindable, so remove it
       // from exports._defaultHosts and start over
-      if (err.code === 'EADDRNOTAVAIL') {
+      if (err.code === 'EADDRNOTAVAIL' || err.code === 'EINVAL') {
 
         if (options.host === err.address) {
           // if bad address matches host given by user, tell them

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -12,7 +12,12 @@ var fs = require('fs'),
     net = require('net'),
     path = require('path'),
     async = require('async'),
+    debug = require('debug'),
     mkdirp = require('mkdirp').mkdirp;
+
+var debugTestPort = debug('portfinder:testPort'),
+    debugGetPort = debug('portfinder:getPort'),
+    debugDefaultHosts = debug('portfinder:defaultHosts');
 
 var internals = {};
 
@@ -30,10 +35,10 @@ internals.testPort = function(options, callback) {
     //
   });
 
-  console.log("entered testPort(): trying", options.host, "port", options.port);
+  debugTestPort("entered testPort(): trying", options.host, "port", options.port);
 
   function onListen () {
-    console.log("done w/ testPort(): OK", options.host, "port", options.port);
+    debugTestPort("done w/ testPort(): OK", options.host, "port", options.port);
 
     options.server.removeListener('error', onError);
     options.server.close();
@@ -41,8 +46,7 @@ internals.testPort = function(options, callback) {
   }
 
   function onError (err) {
-    console.log("done w/ testPort(): failed", options.host, "w/ port",
-                options.port, "with error", err.code);
+    debugTestPort("done w/ testPort(): failed", options.host, "w/ port", options.port, "with error", err.code);
 
     options.server.removeListener('listening', onListen);
 
@@ -104,14 +108,14 @@ exports.getPort = function (options, callback) {
 
   var openPorts = [];
   return async.eachSeries(exports._defaultHosts, function(host, next) {
-    console.log("in eachSeries() iteration callback: host is", host);
+    debugGetPort("in eachSeries() iteration callback: host is", host);
 
     return internals.testPort({ host: host, port: options.port }, function(err, port) {
       if (err) {
-        console.log("in eachSeries() iteration callback testPort() callback", "with an err:", err.code);
+        debugGetPort("in eachSeries() iteration callback testPort() callback", "with an err:", err.code);
         return next(err);
       } else {
-        console.log("in eachSeries() iteration callback testPort() callback",
+        debugGetPort("in eachSeries() iteration callback testPort() callback",
                     "with a success for port", port);
         openPorts.push(port);
         return next();
@@ -120,7 +124,7 @@ exports.getPort = function (options, callback) {
   }, function(err) {
 
     if (err) {
-      console.log("in eachSeries() result callback: err is", err);
+      debugGetPort("in eachSeries() result callback: err is", err);
       // If we get EADDRNOTAVAIL it means the host is not bindable, so remove it
       // from exports._defaultHosts and start over. For ubuntu, we use EINVAL for the same
       if (err.code === 'EADDRNOTAVAIL' || err.code === 'EINVAL') {
@@ -149,7 +153,7 @@ exports.getPort = function (options, callback) {
       return a - b;
     });
 
-    console.log("in eachSeries() result callback: openPorts is", openPorts);
+    debugGetPort("in eachSeries() result callback: openPorts is", openPorts);
 
     if (openPorts[0] === openPorts[openPorts.length-1]) {
       // if first === last, we found an open port
@@ -399,5 +403,8 @@ exports._defaultHosts = (function() {
       results.push(curr.address);
     }
   }
+
+  debugDefaultHosts("exports._defaultHosts is: %o", results);
+
   return results;
 }());

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -106,13 +106,14 @@ exports.getPort = function (options, callback) {
 
   }
 
-  var openPorts = [];
+  var openPorts = [], currentHost;
   return async.eachSeries(exports._defaultHosts, function(host, next) {
     debugGetPort("in eachSeries() iteration callback: host is", host);
 
     return internals.testPort({ host: host, port: options.port }, function(err, port) {
       if (err) {
         debugGetPort("in eachSeries() iteration callback testPort() callback", "with an err:", err.code);
+        currentHost = host;
         return next(err);
       } else {
         debugGetPort("in eachSeries() iteration callback testPort() callback",
@@ -128,8 +129,7 @@ exports.getPort = function (options, callback) {
       // If we get EADDRNOTAVAIL it means the host is not bindable, so remove it
       // from exports._defaultHosts and start over. For ubuntu, we use EINVAL for the same
       if (err.code === 'EADDRNOTAVAIL' || err.code === 'EINVAL') {
-
-        if (options.host === err.address) {
+        if (options.host === currentHost) {
           // if bad address matches host given by user, tell them
           //
           // NOTE: We may need to one day handle `my-non-existent-host.local` if users
@@ -139,7 +139,7 @@ exports.getPort = function (options, callback) {
           return callback(Error(msg));
         }
 
-        var idx = exports._defaultHosts.indexOf(err.address);
+        var idx = exports._defaultHosts.indexOf(currentHost);
         exports._defaultHosts.splice(idx, 1);
         return exports.getPort(options, callback);
       } else {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "async": "^1.5.2",
+    "debug": "^2.2.0",
     "mkdirp": "0.5.x"
   },
   "devDependencies": {

--- a/test/helper.js
+++ b/test/helper.js
@@ -26,7 +26,7 @@ module.exports = function(servers, callback) {
   async.whilst(
     function () { return base < 32773; },
     function (next) {
-      var hosts = ['127.0.0.1', '0.0.0.0', '::1'];
+      var hosts = ['localhost'];
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }
       servers.push(createServer(base, hosts.shift(), next)); // call next for host
       base++;

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,8 +1,7 @@
 "use strict";
 
 var async = require('async'),
-    http = require('http'),
-    portfinder = require('..');
+    http = require('http');
 
 
 function createServer(base, host, next) {
@@ -27,7 +26,7 @@ module.exports = function(servers, callback) {
   async.whilst(
     function () { return base < 32773; },
     function (next) {
-      var hosts = ['localhost'].concat(portfinder._defaultHosts);
+      var hosts = ['localhost'];
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }
       servers.push(createServer(base, hosts.shift(), next)); // call next for host
       base++;

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,8 +1,7 @@
 "use strict";
 
 var async = require('async'),
-    http = require('http'),
-    portfinder = require('..');
+    http = require('http');
 
 
 function createServer(base, host, next) {
@@ -27,7 +26,7 @@ module.exports = function(servers, callback) {
   async.whilst(
     function () { return base < 32773; },
     function (next) {
-      var hosts = [].concat(portfinder._defaultHosts);
+      var hosts = ['127.0.0.1', '0.0.0.0', '::1'];
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }
       servers.push(createServer(base, hosts.shift(), next)); // call next for host
       base++;

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var async = require('async'),
-    http = require('http');
+    http = require('http'),
+    portfinder = require('..');
 
 
 function createServer(base, host, next) {
@@ -26,7 +27,7 @@ module.exports = function(servers, callback) {
   async.whilst(
     function () { return base < 32773; },
     function (next) {
-      var hosts = ['127.0.0.1', '0.0.0.0', '::1'];
+      var hosts = [].concat(portfinder._defaultHosts);
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }
       servers.push(createServer(base, hosts.shift(), next)); // call next for host
       base++;

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var async = require('async'),
-    http = require('http');
+    http = require('http'),
+    portfinder = require('..');
 
 
 function createServer(base, host, next) {
@@ -26,7 +27,7 @@ module.exports = function(servers, callback) {
   async.whilst(
     function () { return base < 32773; },
     function (next) {
-      var hosts = ['localhost'];
+      var hosts = ['localhost'].concat(portfinder._defaultHosts);
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }
       servers.push(createServer(base, hosts.shift(), next)); // call next for host
       base++;

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -17,7 +17,11 @@ var debugVows = debug('portfinder:testVows');
 
 portfinder.basePort = 32768;
 
-var servers = [];
+var servers = [], counter = 1, _increment_ = 1000;
+
+function increment() {
+  return (counter+=1)*_increment_;
+}
 
 vows.describe('portfinder').addBatch({
   "When using portfinder module": {
@@ -27,7 +31,9 @@ vows.describe('portfinder').addBatch({
       },
       "the getPorts() method with an argument of 3": {
         topic: function () {
-          portfinder.getPorts(3, this.callback);
+          setTimeout(function() {
+            portfinder.getPorts(3, this.callback);
+          }.bind(this), increment());
         },
         "should respond with the first three available ports (32773, 32774, 32775)": function (err, ports) {
           if (err) { debugVows(err); }
@@ -49,7 +55,9 @@ vows.describe('portfinder').addBatch({
       },
       "the getPorts() method with an argument of 3": {
         topic: function () {
-          portfinder.getPorts(3, this.callback);
+          setTimeout(function() {
+            portfinder.getPorts(3, this.callback);
+          }.bind(this), increment());
         },
         "should respond with the first three available ports (32768, 32769, 32770)": function (err, ports) {
           if (err) { debugVows(err); }

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -27,7 +27,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32773, 32774, 32775)": function (err, ports) {
-          assert.isTrue(!err);
+          if (err) { console.error(err); }
           assert.deepEqual(ports, [32773, 32774, 32775]);
         }
       }
@@ -48,7 +48,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32768, 32769, 32770)": function (err, ports) {
-          assert.isTrue(!err);
+          if (err) { console.error(err); }
           assert.deepEqual(ports, [32768, 32769, 32770]);
         }
       }

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -27,6 +27,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32773, 32774, 32775)": function (err, ports) {
+          assert.isTrue(!err);
           if (err) { console.error(err); }
           assert.deepEqual(ports, [32773, 32774, 32775]);
         }
@@ -48,6 +49,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32768, 32769, 32770)": function (err, ports) {
+          assert.isTrue(!err);
           if (err) { console.error(err); }
           assert.deepEqual(ports, [32768, 32769, 32770]);
         }

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -27,8 +27,8 @@ vows.describe('portfinder').addBatch({
           portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32773, 32774, 32775)": function (err, ports) {
-          assert.isTrue(!err);
           if (err) { console.error(err); }
+          assert.isTrue(!err);
           assert.deepEqual(ports, [32773, 32774, 32775]);
         }
       }
@@ -49,8 +49,8 @@ vows.describe('portfinder').addBatch({
           portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32768, 32769, 32770)": function (err, ports) {
-          assert.isTrue(!err);
           if (err) { console.error(err); }
+          assert.isTrue(!err);
           assert.deepEqual(ports, [32768, 32769, 32770]);
         }
       }

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -17,11 +17,7 @@ var debugVows = debug('portfinder:testVows');
 
 portfinder.basePort = 32768;
 
-var servers = [], counter = 1, _increment_ = 1000;
-
-function increment() {
-  return (counter+=1)*_increment_;
-}
+var servers = [];
 
 vows.describe('portfinder').addBatch({
   "When using portfinder module": {
@@ -31,9 +27,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPorts() method with an argument of 3": {
         topic: function () {
-          setTimeout(function() {
-            portfinder.getPorts(3, this.callback);
-          }.bind(this), increment());
+          portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32773, 32774, 32775)": function (err, ports) {
           if (err) { debugVows(err); }
@@ -55,9 +49,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPorts() method with an argument of 3": {
         topic: function () {
-          setTimeout(function() {
-            portfinder.getPorts(3, this.callback);
-          }.bind(this), increment());
+          portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32768, 32769, 32770)": function (err, ports) {
           if (err) { debugVows(err); }

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -10,7 +10,10 @@
 var vows = require('vows'),
     assert = require('assert'),
     portfinder = require('../lib/portfinder'),
-    testHelper = require('./helper');
+    testHelper = require('./helper'),
+    debug = require('debug');
+
+var debugVows = debug('portfinder:testVows');
 
 portfinder.basePort = 32768;
 
@@ -27,7 +30,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32773, 32774, 32775)": function (err, ports) {
-          if (err) { console.error(err); }
+          if (err) { debugVows(err); }
           assert.isTrue(!err);
           assert.deepEqual(ports, [32773, 32774, 32775]);
         }
@@ -49,7 +52,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPorts(3, this.callback);
         },
         "should respond with the first three available ports (32768, 32769, 32770)": function (err, ports) {
-          if (err) { console.error(err); }
+          if (err) { debugVows(err); }
           assert.isTrue(!err);
           assert.deepEqual(ports, [32768, 32769, 32770]);
         }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -27,6 +27,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32773)": function (err, port) {
+          assert.isTrue(!err);
           if (err) { console.error(err); }
           assert.equal(port, 32773);
         }
@@ -36,6 +37,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort({ host: '127.0.0.1' }, this.callback);
         },
         "should respond with the first free port (32774)": function (err, port) {
+          assert.isTrue(!err);
           if (err) { console.error(err); }
           assert.equal(port, 32774);
         }
@@ -57,6 +59,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32768)": function (err, port) {
+          assert.isTrue(!err);
           if (err) { console.error(err); }
           assert.equal(port, 32768);
         }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -37,7 +37,9 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method with user passed duplicate host": {
         topic: function () {
-          portfinder.getPort({ host: 'localhost' }, this.callback);
+          setTimeout(function() {
+            portfinder.getPort({ host: 'localhost' }, this.callback);
+          }.bind(this), 3000); // wait for cleanup of bound hosts
         },
         "should respond with the first free port (32773)": function (err, port) {
           if (err) { debugVows(err); }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -27,7 +27,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32773)": function (err, port) {
-          assert.isTrue(!err);
+          if (err) { console.error(err); }
           assert.equal(port, 32773);
         }
       },
@@ -36,7 +36,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort({ host: '127.0.0.1' }, this.callback);
         },
         "should respond with the first free port (32774)": function (err, port) {
-          assert.isTrue(!err);
+          if (err) { console.error(err); }
           assert.equal(port, 32774);
         }
       }
@@ -57,7 +57,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32768)": function (err, port) {
-          assert.isTrue(!err);
+          if (err) { console.error(err); }
           assert.equal(port, 32768);
         }
       }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -10,7 +10,10 @@
 var vows = require('vows'),
     assert = require('assert'),
     portfinder = require('../lib/portfinder'),
-    testHelper = require('./helper');
+    testHelper = require('./helper'),
+    debug = require('debug');
+
+var debugVows = debug('portfinder:testVows');
 
 portfinder.basePort = 32768;
 
@@ -27,8 +30,8 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32773)": function (err, port) {
+          if (err) { debugVows(err); }
           assert.isTrue(!err);
-          if (err) { console.error(err); }
           assert.equal(port, 32773);
         }
       },
@@ -39,7 +42,7 @@ vows.describe('portfinder').addBatch({
           }.bind(this), 1000);
         },
         "should respond with the first free port (32773)": function (err, port) {
-          if (err) { console.error(err); }
+          if (err) { debugVows(err); }
           assert.isTrue(!err);
           assert.equal(port, 32773);
         }
@@ -61,7 +64,7 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32768)": function (err, port) {
-          if (err) { console.error(err); }
+          if (err) { debugVows(err); }
           assert.isTrue(!err);
           assert.equal(port, 32768);
         }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -17,7 +17,11 @@ var debugVows = debug('portfinder:testVows');
 
 portfinder.basePort = 32768;
 
-var servers = [];
+var servers = [], counter = 1, _increment_ = 1000;
+
+function increment() {
+  return (counter+=1)*_increment_;
+}
 
 vows.describe('portfinder').addBatch({
   "When using portfinder module": {
@@ -27,7 +31,9 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method": {
         topic: function () {
-          portfinder.getPort(this.callback);
+          setTimeout(function() {
+            portfinder.getPort(this.callback);
+          }.bind(this), increment());
         },
         "should respond with the first free port (32773)": function (err, port) {
           if (err) { debugVows(err); }
@@ -39,7 +45,7 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           setTimeout(function() {
             portfinder.getPort({ host: 'localhost' }, this.callback);
-          }.bind(this), 1000);
+          }.bind(this), increment());
         },
         "should respond with the first free port (32773)": function (err, port) {
           if (err) { debugVows(err); }
@@ -61,7 +67,9 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method": {
         topic: function () {
-          portfinder.getPort(this.callback);
+          setTimeout(function() {
+            portfinder.getPort(this.callback);
+          }.bind(this), increment());
         },
         "should respond with the first free port (32768)": function (err, port) {
           if (err) { debugVows(err); }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -34,11 +34,13 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method with user passed duplicate host": {
         topic: function () {
-          portfinder.getPort({ host: 'localhost' }, this.callback);
+          setTimeout(function() {
+            portfinder.getPort({ host: 'localhost' }, this.callback);
+          }.bind(this), 1000);
         },
         "should respond with the first free port (32773)": function (err, port) {
-          assert.isTrue(!err);
           if (err) { console.error(err); }
+          assert.isTrue(!err);
           assert.equal(port, 32773);
         }
       }
@@ -59,8 +61,8 @@ vows.describe('portfinder').addBatch({
           portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32768)": function (err, port) {
-          assert.isTrue(!err);
           if (err) { console.error(err); }
+          assert.isTrue(!err);
           assert.equal(port, 32768);
         }
       }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -34,12 +34,12 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method with user passed duplicate host": {
         topic: function () {
-          portfinder.getPort({ host: '127.0.0.1' }, this.callback);
+          portfinder.getPort({ host: 'localhost' }, this.callback);
         },
-        "should respond with the first free port (32774)": function (err, port) {
+        "should respond with the first free port (32773)": function (err, port) {
           assert.isTrue(!err);
           if (err) { console.error(err); }
-          assert.equal(port, 32774);
+          assert.equal(port, 32773);
         }
       }
     }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -17,11 +17,7 @@ var debugVows = debug('portfinder:testVows');
 
 portfinder.basePort = 32768;
 
-var servers = [], counter = 1, _increment_ = 1000;
-
-function increment() {
-  return (counter+=1)*_increment_;
-}
+var servers = [];
 
 vows.describe('portfinder').addBatch({
   "When using portfinder module": {
@@ -31,9 +27,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method": {
         topic: function () {
-          setTimeout(function() {
-            portfinder.getPort(this.callback);
-          }.bind(this), increment());
+          portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32773)": function (err, port) {
           if (err) { debugVows(err); }
@@ -43,9 +37,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method with user passed duplicate host": {
         topic: function () {
-          setTimeout(function() {
-            portfinder.getPort({ host: 'localhost' }, this.callback);
-          }.bind(this), increment());
+          portfinder.getPort({ host: 'localhost' }, this.callback);
         },
         "should respond with the first free port (32773)": function (err, port) {
           if (err) { debugVows(err); }
@@ -67,9 +59,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method": {
         topic: function () {
-          setTimeout(function() {
-            portfinder.getPort(this.callback);
-          }.bind(this), increment());
+          portfinder.getPort(this.callback);
         },
         "should respond with the first free port (32768)": function (err, port) {
           if (err) { debugVows(err); }

--- a/test/port-finder-z-integration-test.js
+++ b/test/port-finder-z-integration-test.js
@@ -1,6 +1,13 @@
 /*
+NOTE: the z in this file name is so this test runs last. It was causing issues
+when run first, most likely due to its cleanup time (which made its bound hosts
+ confilct with the former 'next' tests, which now run 'before' this test instead,
+hence the 'z' in the name of this file).
+ */
+
+/*
  * port-finder-0-vs-127-test.js: Test for the `portfinder` module.
- * that demonstrates issue #24 
+ * that demonstrates issue #24
  * https://github.com/indexzero/node-portfinder/issues/24
  */
 
@@ -26,7 +33,7 @@ vows.describe('portfinder').addBatch({
         var timer = setTimeout(function() {
           timeout = true;
           process.kill(child.pid);
-          callback(null, "timeout");  
+          callback(null, "timeout");
         }, 10000); // 10 seconds
         var child = child_process.spawn('node', [fileToExec,  port]);
         child.on('close', function() {
@@ -35,7 +42,7 @@ vows.describe('portfinder').addBatch({
             callback(null);
           }
         });
-      });  
+      });
     });
       },
       "should not get a timeout": function (err, res) {


### PR DESCRIPTION
Catch EADDRNOTAVAIL to filter out non-bindable hosts before iterating through ports

The general idea here is to filter out non-bindable hosts prior to looking for an open port so that we don't try to guess what hosts are bindable. 

Specifically worth noting though is that **the way this works does not actually filter all hosts before trying to find a port, it interleaves the two**. In practice however, the interfaces produced by `os.networkInterfaces()` are ordered from least to most likely to 'be bindable' so for most imaginable use cases, the port found will be 'the next open port for all bindable hosts' on the machine. There are cases however, for example when binding to an address from the "host machine" -> VM, where catching `EADDRNOTAVAIL` will (for example) discard 2 potentially working ports while also discarding the hosts that raised `EADDRNOTAVAIL`. Given the tradeoff between simple and 'less simple' this PR chose the simple path with the goal being to isolate the simplest change. This can be iterated on once we know this is the correct fix, although there is likely little to gain.