### PR TITLE
Don't bail when os.networkInterfaces is not supported.

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -395,6 +395,7 @@ exports._defaultHosts = (function() {
   var interfaces = {};
   try{
     interfaces = os.networkInterfaces();
+  }
   catch(){
     // swallow error because we're just going to use defaults
   }

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -392,8 +392,13 @@ exports.nextSocket = function (socketPath) {
  *     Note we export this so we can use it in our tests, otherwise this API is private
  */
 exports._defaultHosts = (function() {
-  var interfaces = os.networkInterfaces(),
-      interfaceNames = Object.keys(interfaces),
+  var interfaces = {};
+  try{
+    interfaces = os.networkInterfaces();
+  catch(){
+    // swallow error because we're just going to use defaults
+  }
+  var interfaceNames = Object.keys(interfaces),
       hiddenButImportantHost = '0.0.0.0', // !important - dont remove, hence the naming :)
       results = [hiddenButImportantHost];
   for (var i = 0; i < interfaceNames.length; i++) {

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -396,7 +396,7 @@ exports._defaultHosts = (function() {
   try{
     interfaces = os.networkInterfaces();
   }
-  catch(){
+  catch(e){
     // swallow error because we're just going to use defaults
   }
   var interfaceNames = Object.keys(interfaces),


### PR DESCRIPTION
Usage of non-supported operation under Windows Subsystem for Linux

os.networkInterfaces(), line 395, throws a not supported error on WSL (bash for windows). 

The operation will be supported at some point, but for now, I would want it to not crash and just return default values.