### PR TITLE
Fix windows 10 support

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -16,6 +16,7 @@ var fs = require('fs'),
     mkdirp = require('mkdirp').mkdirp;
 
 var debugTestPort = debug('portfinder:testPort'),
+    debugTryConnection = debug('portfinder:tryConnection'),
     debugGetPort = debug('portfinder:getPort'),
     debugDefaultHosts = debug('portfinder:defaultHosts');
 
@@ -29,20 +30,40 @@ internals.testPort = function(options, callback) {
 
   options.port   = options.port   || exports.basePort;
   options.host   = options.host   || null;
-  options.server = options.server || net.createServer(function () {
-    //
-    // Create an empty listener for the port testing server.
-    //
+  options.server = options.server || net.createServer(function (connection) {
+    connection.pipe(connection);
   });
 
   debugTestPort("entered testPort(): trying", options.host, "port", options.port);
 
   function onListen () {
+    internals.windows10BindError = {
+      message: 'client and server unable to communicate over '+options.server.address(),
+      code: 'windows10BindError'
+    }
+
     debugTestPort("done w/ testPort(): OK", options.host, "port", options.port);
 
-    options.server.removeListener('error', onError);
-    options.server.close();
-    callback(null, options.port);
+    var client = net.createConnection(options, function() {
+      client.write('OK PORTFINDER');
+    });
+
+    client.setEncoding('utf8');
+    client.on('data', function(data) {
+      debugTryConnection('Try Connection client -> server -> client: ', data);
+
+      if (data === 'OK PORTFINDER') {
+        options.server.removeListener('error', onError);
+        options.server.close();
+        client.end();
+      } else {
+        options.server.emit('error', new Error(internals.windows10BindError));
+      }
+    });
+
+    client.on('end', function() {
+      callback(null, options.port);
+    });
   }
 
   function onError (err) {
@@ -50,7 +71,7 @@ internals.testPort = function(options, callback) {
 
     options.server.removeListener('listening', onListen);
 
-    if (err.code !== 'EADDRINUSE' && err.code !== 'EACCES') {
+    if (err.code !== 'EADDRINUSE' && err.code !== 'EACCES' && err.code !== internals.windows10BindError.code) {
       return callback(err);
     }
 
@@ -379,7 +400,6 @@ exports.nextSocket = function (socketPath) {
  *    - Output:
  *
  *         [
- *          '0.0.0.0',
  *          '::1',
  *          '127.0.0.1',
  *          'fe80::1',
@@ -392,10 +412,28 @@ exports.nextSocket = function (socketPath) {
  *     Note we export this so we can use it in our tests, otherwise this API is private
  */
 exports._defaultHosts = (function() {
-  var interfaces = os.networkInterfaces(),
-      interfaceNames = Object.keys(interfaces),
-      hiddenButImportantHost = '0.0.0.0', // !important - dont remove, hence the naming :)
-      results = [hiddenButImportantHost];
+
+  var interfaces = {};
+  try{
+    interfaces = os.networkInterfaces();
+  }
+  catch(e) {
+    // As of October 2016, Windows Subsystem for Linux (WSL) does not support
+    // the os.networkInterfaces() call and throws instead. For this platform,
+    // assume 0.0.0.0 as the only address
+    //
+    // - https://github.com/Microsoft/BashOnWindows/issues/468
+    if (e.syscall === 'uv_interface_addresses') {
+      debugDefaultHosts("exports._defaultHosts is reverting to dumb logic to account for Windows on Bash bug https://github.com/Microsoft/BashOnWindows/issues/1181. Original Error is: %o", e);
+      return ['0.0.0.0'];
+    } else {
+      throw e;
+    }
+  }
+
+  var interfaceNames = Object.keys(interfaces),
+      results = [];
+
   for (var i = 0; i < interfaceNames.length; i++) {
     var _interface = interfaces[interfaceNames[i]];
     for (var j = 0; j < _interface.length; j++) {

--- a/test/port-finder-z-integration-test.js
+++ b/test/port-finder-z-integration-test.js
@@ -34,7 +34,7 @@ vows.describe('portfinder').addBatch({
           timeout = true;
           process.kill(child.pid);
           callback(null, "timeout");
-        }, 10000); // 10 seconds
+        }, 20000); // 10 seconds
         var child = child_process.spawn('node', [fileToExec,  port]);
         child.on('close', function() {
           if (timeout === false) {


### PR DESCRIPTION
- Windows 10 native shell(#39) was rebinding to already bound ports. We
  now send a message from a socket client -> server -> client to ensure
  a host + port are actually open
- Windows 10 bash shell falls back to using 0.0.0.0 as the only host we
  check in order to prevent throwing a syscall error as being tracked here:
  https://github.com/Microsoft/BashOnWindows/issues/468

fixes: #39
closes: #41
fixes: https://github.com/ember-cli/ember-cli/issues/6338