### PR TITLE
Promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ The `portfinder` module has a simple interface:
   });
 ```
 
+Or with promise (if Promise are supported) :
+
+``` js
+  const portfinder = require('portfinder');
+
+  portfinder.getPortPromise()
+    .then((port) => {
+        //
+        // `port` is guaranteed to be a free port
+        // in this scope.
+        //
+    })
+    .catch((err) => {
+        //
+        // Could not get a free port, `err` contains the reason.
+        //
+    });
+```
+
+
 By default `portfinder` will start searching from `8000`. To change this simply set `portfinder.basePort`.
 
 ## Run Tests

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -167,6 +167,27 @@ exports.getPort = function (options, callback) {
 };
 
 //
+// ### function getPortPromise (options)
+// #### @options {Object} Settings to use when finding the necessary port
+// Responds a promise to an unbound port on the current machine.
+//
+if (typeof Promise === 'function') {
+  exports.getPortPromise = function (options) {
+    if (!options) {
+      options = {};
+    }
+    return new Promise(function(resolve, reject) {
+      exports.getPort(options, function(err, port) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(port);
+      });
+    });
+  };
+}
+
+//
 // ### function getPorts (count, options, callback)
 // #### @count {Number} The number of ports to find
 // #### @options {Object} Settings to use when finding the necessary port

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -40,22 +40,24 @@ vows.describe('portfinder').addBatch({
           var vow = this;
 
           if (typeof Promise === 'function') {
-            portfinder.getPortPromise()
-              .then(function (port) {
-                vow.callback(null, port);
-              })
-              .catch(function (err) {
-                vow.callback(err, null);
-              });
+            setTimeout(function() {
+              portfinder.getPortPromise()
+                .then(function (port) {
+                  vow.callback(null, port);
+                })
+                .catch(function (err) {
+                  vow.callback(err, null);
+                });
+            }.bind(this), 3000); // wait for cleanup of bound hosts
           } else {
             this.callback(null, 'not applicable')
           }
         },
-        "should respond with a promise of first free port (32774) if Promise are available": function (err, port) {
+        "should respond with a promise of first free port (32773) if Promise are available": function (err, port) {
           if (err) { debugVows(err); }
           assert.isTrue(!err);
           if (port !== 'not applicable') {
-            assert.equal(port, 32774);
+            assert.equal(port, 32773);
           }
         }
       },

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -35,6 +35,30 @@ vows.describe('portfinder').addBatch({
           assert.equal(port, 32773);
         }
       },
+      "the getPortPromise() method": {
+        topic: function () {
+          var vow = this;
+
+          if (typeof Promise === 'function') {
+            portfinder.getPortPromise()
+              .then(function (port) {
+                vow.callback(null, port);
+              })
+              .catch(function (err) {
+                vow.callback(err, null);
+              });
+          } else {
+            this.callback(null, 'not applicable')
+          }
+        },
+        "should respond with a promise of first free port (32774) if Promise are available": function (err, port) {
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          if (port !== 'not applicable') {
+            assert.equal(port, 32774);
+          }
+        }
+      },
       "the getPort() method with user passed duplicate host": {
         topic: function () {
           setTimeout(function() {


### PR DESCRIPTION
Adds a `getPortPromise()` method that returns a Promise to the next free port : 

```js
const portfinder = require('portfinder');

portfinder.getPortPromise()
  .then((port) => {
      //
      // `port` is guaranteed to be a free port
      // in this scope.
      //
  })
  .catch((err) => {
      //
      // Could not get a free port, `err` contains the reason.
      //
  });
```

As  `getPortPromise()` is only a wrapper around `getPort()` I only added a simple unit test.