### PR TITLE
Promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Or with promise (if Promise are supported) :
     });
 ```
 
+If `portfinder.getPortPromise()` is called on a Node version without Promise (<4), it will throw an Error unless [Bluebird](http://bluebirdjs.com/docs/getting-started.html) or any Promise pollyfill is used.
 
 By default `portfinder` will start searching from `8000`. To change this simply set `portfinder.basePort`.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ The `portfinder` module has a simple interface:
   });
 ```
 
+Or with promise (if Promise are supported) :
+
+``` js
+  const portfinder = require('portfinder');
+
+  portfinder.getPortPromise()
+    .then((port) => {
+        //
+        // `port` is guaranteed to be a free port
+        // in this scope.
+        //
+    })
+    .catch((err) => {
+        //
+        // Could not get a free port, `err` contains the reason.
+        //
+    });
+```
+
+
 By default `portfinder` will start searching from `8000`. To change this simply set `portfinder.basePort`.
 
 ## Run Tests

--- a/lib/portfinder.d.ts
+++ b/lib/portfinder.d.ts
@@ -27,3 +27,7 @@ export let basePort: number;
  */
 export function getPort(callback: PortfinderCallback): void;
 export function getPort(options: PortFinderOptions, callback: PortfinderCallback): void;
+/**
+ * Responds a promise of an unbound port on the current machine.
+ */
+export function getPortPromise(options?: PortFinderOptions): Promise<number>;

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -171,20 +171,22 @@ exports.getPort = function (options, callback) {
 // #### @options {Object} Settings to use when finding the necessary port
 // Responds a promise to an unbound port on the current machine.
 //
-if (typeof Promise === 'function') {
-  exports.getPortPromise = function (options) {
-    if (!options) {
-      options = {};
-    }
-    return new Promise(function(resolve, reject) {
-      exports.getPort(options, function(err, port) {
-        if (err) {
-          return reject(err);
-        }
-        resolve(port);
-      });
+exports.getPortPromise = function (options) {
+  if (typeof Promise !== 'function') {
+    throw Error('Native promise support is not available in this version of node.' +
+      'Please install a polyfill and assign Promise to global.Promise before calling this method');
+  }
+  if (!options) {
+    options = {};
+  }
+  return new Promise(function(resolve, reject) {
+    exports.getPort(options, function(err, port) {
+      if (err) {
+        return reject(err);
+      }
+      resolve(port);
     });
-  };
+  });
 }
 
 //

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -167,6 +167,27 @@ exports.getPort = function (options, callback) {
 };
 
 //
+// ### function getPortPromise (options)
+// #### @options {Object} Settings to use when finding the necessary port
+// Responds a promise to an unbound port on the current machine.
+//
+if (typeof Promise === 'function') {
+  exports.getPortPromise = function (options) {
+    if (!options) {
+      options = {};
+    }
+    return new Promise(function(resolve, reject) {
+      exports.getPort(options, function(err, port) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(port);
+      });
+    });
+  };
+}
+
+//
 // ### function getPorts (count, options, callback)
 // #### @count {Number} The number of ports to find
 // #### @options {Object} Settings to use when finding the necessary port

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -71,4 +71,40 @@ vows.describe('portfinder').addBatch({
       }
     }
   }
+}).addBatch({
+  "When using portfinder module": {
+    "with no existing servers": {
+      topic: function () {
+        servers.forEach(function (server) {
+          server.close();
+        });
+
+        return null;
+      },
+      "the getPortPromise() method": {
+        topic: function () {
+          var vow = this;
+
+          if (typeof Promise === 'function') {
+            portfinder.getPortPromise()
+              .then(function (port) {
+                vow.callback(null, port);
+              })
+              .catch(function (err) {
+                vow.callback(err, null);
+              });
+          } else {
+            this.callback(null, 'not applicable')
+          }
+        },
+        "should respond with a promise of first free port (32768) if Promise are available": function (err, port) {
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          if (port !== 'not applicable') {
+            assert.equal(port, 32768);
+          }
+        }
+      },
+    }
+  }
 }).export(module);

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -85,24 +85,27 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           var vow = this;
 
-          if (typeof Promise === 'function') {
-            portfinder.getPortPromise()
-              .then(function (port) {
-                vow.callback(null, port);
-              })
-              .catch(function (err) {
-                vow.callback(err, null);
-              });
-          } else {
-            this.callback(null, 'not applicable')
-          }
+          portfinder.getPortPromise()
+            .then(function (port) {
+              vow.callback(null, port);
+            })
+            .catch(function (err) {
+              vow.callback(err, null);
+            });
         },
         "should respond with a promise of first free port (32768) if Promise are available": function (err, port) {
+          if (typeof Promise !== 'function') {
+            assert.isTrue(!!err);
+            assert.equal(
+              err.message,
+              'Native promise support is not available in this version of node.' +
+              'Please install a polyfill and assign Promise to global.Promise before calling this method'
+            );
+            return;
+          }
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          if (port !== 'not applicable') {
-            assert.equal(port, 32768);
-          }
+          assert.equal(port, 32768);
         }
       },
     }


### PR DESCRIPTION
Adds `getPortPromise()` which returns a Promise to the next available port : 

``` js
  const portfinder = require('portfinder');

  portfinder.getPortPromise()
    .then((port) => {
        //
        // `port` is guaranteed to be a free port
        // in this scope.
        //
    })
    .catch((err) => {
        //
        // Could not get a free port, `err` contains the reason.
        //
    });
```

