### PR TITLE
Make test close listening sockets instead of just removing them

### DIFF
--- a/test/port-finder-socket-test.js
+++ b/test/port-finder-socket-test.js
@@ -54,13 +54,23 @@ function createServers (callback) {
     }, callback);
 }
 
+function stopServers(callback, index) {
+  if (index < servers.length) {
+    servers[index].close(function (err) {
+      if (err) {
+        callback(err, false);
+      } else {
+        stopServers(callback, index + 1);
+      }
+    });
+  } else {
+    callback(null, true);
+  }
+}
+
 function cleanup(callback) {
   fs.rmdirSync(badDir);
-  glob(path.resolve(socketDir, '*'), function (err, files) {
-    if (err) { callback(err); }
-    for (var i = 0; i < files.length; i++) { fs.unlinkSync(files[i]); }
-    callback(null, true);
-  });
+  stopServers(callback, 0);
 }
 
 vows.describe('portfinder').addBatch({


### PR DESCRIPTION
Without this I see the tests (with node 6.10.2) completing but then just hanging because the servers are still listening on the sockets.