### PR TITLE
Update portfinder to convert option.port to number

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -27,7 +27,7 @@ internals.testPort = function(options, callback) {
     options = {};
   }
 
-  options.port   = +options.port   || exports.basePort;
+  options.port   = Number(options.port) || Number(exports.basePort);
   options.host   = options.host    || null;
   options.server = options.server  || net.createServer(function () {
     //

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -27,9 +27,9 @@ internals.testPort = function(options, callback) {
     options = {};
   }
 
-  options.port   = options.port   || exports.basePort;
-  options.host   = options.host   || null;
-  options.server = options.server || net.createServer(function () {
+  options.port   = +options.port   || exports.basePort;
+  options.host   = options.host    || null;
+  options.server = options.server  || net.createServer(function () {
     //
     // Create an empty listener for the port testing server.
     //


### PR DESCRIPTION
Hi! Got a strange error while working on an angular app. For some reason, when I try to get the server up it throws the error below.
Obviously, when it receives '8080', everything crashes and according to exports.basePort options.port always should be of a number type.

~ ng s
│net.js:1487
│      throw new errors.RangeError('ERR_SOCKET_BAD_PORT', options.port);
│      ^
│
│RangeError [ERR_SOCKET_BAD_PORT]: Port should be > 0 and < 65536. Received 80801.
│    at Server.listen (net.js:1487:13)
│    at Object.internals.testPort (/<projectPath>/node_modules/portfinder/lib/portfinder.js:69:18
│)
│    at Server.onError (/<projectPath>/node_modules/portfinder/lib/portfinder.js:60:15)
│    at Object.onceWrapper (events.js:254:19)
│    at Server.emit (events.js:159:13)
│    at emitErrorNT (net.js:1387:8)
│    at _combinedTickCallback (internal/process/next_tick.js:138:11)
│    at process._tickCallback (internal/process/next_tick.js:180:9)