### PR TITLE
fixed port is not detects without host.

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -61,7 +61,17 @@ internals.testPort = function(options, callback) {
 
   options.server.once('error', onError);
   options.server.once('listening', onListen);
-  options.server.listen(options.port, options.host);
+
+  if (options.host) {
+    options.server.listen(options.port, options.host);
+  } else {
+    /* 
+      Judgement of service without host
+      example:
+        express().listen(options.port) 
+    */
+    options.server.listen(options.port);
+  }
 };
 
 //
@@ -472,6 +482,9 @@ exports._defaultHosts = (function() {
       results.push(curr.address);
     }
   }
+
+  // add null value, For createServer function, do not use host.
+  results.push(null);
 
   debugDefaultHosts("exports._defaultHosts is: %o", results);
 


### PR DESCRIPTION
_for example:_ 
old :
```
// my-server
let server  = net.createServer(function(){});
server.listen(3000);

portfinder.basePort = 3000;
portfinder.getPort(function(error, port) {
// port -> 3000
});
```

now :
```
// my-server
let server  = net.createServer(function(){});
server.listen(3000);

portfinder.basePort = 3000;
portfinder.getPort(function(error, port) {
// port -> 3001
});

```
**Has passed the test.**