### PR TITLE
Avoid crashing if all ports above the start port are unavailable

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -52,8 +52,14 @@ internals.testPort = function(options, callback) {
       return callback(err);
     }
 
+    var nextPort = exports.nextPort(options.port);
+
+    if (nextPort > exports.highestPort) {
+      return callback(new Error('No open ports available'));
+    }
+
     internals.testPort({
-      port: exports.nextPort(options.port),
+      port: nextPort,
       host: options.host,
       server: options.server
     }, callback);

--- a/test/helper.js
+++ b/test/helper.js
@@ -20,11 +20,18 @@ function createServer(base, host, next) {
   return server;
 }
 
-module.exports = function(servers, callback) {
-  var base = 32768;
+module.exports = function(servers, startPort, endPort, callback) {
+  if (typeof startPort === 'function') {
+    // Make startPort & endPort optional
+    callback = startPort;
+    startPort = undefined;
+  }
+
+  var base = startPort || 32768;
+  endPort = endPort || 32773;
 
   async.whilst(
-    function () { return base < 32773; },
+    function () { return base < endPort; },
     function (next) {
       var hosts = ['localhost'];
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -179,6 +179,29 @@ vows.describe('portfinder').addBatch({
       }
     }
   }
+}).addBatch({
+  "When using portfinder module": {
+    "with no available ports above the start port": {
+      topic: function () {
+        testHelper(servers, 65530, 65536, this.callback);
+      },
+      "the getPort() method requesting an unavailable port": {
+        topic: function () {
+          portfinder.getPort({ port: 65530 }, this.callback);
+        },
+        "should return error": function(err, port) {
+          closeServers() // close all the servers first!
+
+          assert.isTrue(!!err);
+          assert.equal(
+            err.message,
+            'No open ports available'
+          );
+          return;
+        }
+      },
+    }
+  }
 })
 
 .export(module);


### PR DESCRIPTION
Right now, calling `getPort` when _every_ port above the given port is in use will throw:

```
RangeError [ERR_SOCKET_BAD_PORT]: Port should be >= 0 and < 65536. Received 65536.
```

This isn't passed to the callback - it's thrown directly by node. Because this isn't handled at all that will usually crash the whole node process.

To easily reproduce this, start a server on port 65535 (the maximum port), and then run `portfinder.getPortPromise({ port: 65535 })`.

This happens because `testPort` is unbounded, and constantly tries ports until it finds an available one, without checking whether the port to test is valid, so when 65535 is in use it tries to test 65536, which isn't a valid port.

This PR makes `testPort` instead check whether the next port is valid before testing it, so that it fails cleanly if there are no ports available.