### PR TITLE
Fix author field format in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "portfinder",
   "description": "A simple tool to find an open port on the current machine",
   "version": "1.0.37",
-  "author": "Charlie Robbins <charlie.robbins@gmail.com>, Erik Trom <erik.trom@gmail.com>",
+  "author": "Charlie Robbins <charlie.robbins@gmail.com>",
+  "contributors": [
+    "Erik Trom <erik.trom@gmail.com>"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:http-party/node-portfinder.git"


### PR DESCRIPTION
Fixes #181 

PR updates the `author` field and adds `contributors` field to the package.json file following the [package.json docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#people-fields-author-contributors) where `author` must be a singular person, while `contributors` is then an array of further contributors.